### PR TITLE
Bugfix/a and fragment parsing

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -305,6 +305,41 @@ impl Graph {
         Node::UriNode { uri: uri.clone() }
     }
 
+    /// Creates a new URI node from a string slice.
+    /// 
+    /// # Examples
+    ///
+    /// ```
+    /// use rdf::graph::Graph;
+    /// use rdf::node::Node;
+    /// use rdf::uri::Uri;
+    ///
+    /// let graph = Graph::new(None);
+    /// let uri_node = graph.create_uri_node_str("http://example.org/show/localName");
+    ///
+    /// assert_eq!(uri_node, Node::UriNode {
+    ///   uri: Uri::new("http://example.org/show/localName".to_string())
+    /// });
+    /// 
+    /// let graph = Graph::new(Some(&Uri::new("http://www.w3.org/2006/vcard/ns".to_string())));
+    /// let uri_node = graph.create_uri_node_str("#fn");
+    /// assert_eq!(uri_node, Node::UriNode {
+    ///   uri: Uri::new("http://www.w3.org/2006/vcard/ns#fn".to_string())
+    /// });
+    /// ```
+    pub fn create_uri_node_str(&self, uri: &str) -> Node {
+        let uri = match (uri.starts_with("#"),self.base_uri()){
+            (true, Some(base))=> {
+                let mut s = base.to_string().clone();
+                s.push_str(uri);
+                Uri::new(s)
+            },
+            (_,_) =>  Uri::new(uri.to_string())
+        };
+
+        Node::UriNode { uri: uri }
+    }
+
     /// Adds a triple to the graph.
     ///
     /// # Examples

--- a/src/reader/lexer/turtle_lexer.rs
+++ b/src/reader/lexer/turtle_lexer.rs
@@ -145,10 +145,12 @@ pub trait TokensFromTurtle<R: Read>: TokensFromNTriples<R> {
 
     /// Parses the 'a' keyword.
     fn get_a_keyword(input_reader: &mut InputReader<R>) -> Result<Token> {
-        let a =
+        let a = 
             input_reader.peek_until_discard_leading_spaces(InputReaderHelper::node_delimiter)?;
 
         if a.len() == 1 && a[0] == Some('a') {
+            // ok, don't forget to consume the 'a' character
+            let _ =  input_reader.get_next_char();
             return Ok(Token::KeywordA);
         } else {
             return Err(Error::new(

--- a/src/reader/lexer/turtle_lexer.rs
+++ b/src/reader/lexer/turtle_lexer.rs
@@ -145,12 +145,10 @@ pub trait TokensFromTurtle<R: Read>: TokensFromNTriples<R> {
 
     /// Parses the 'a' keyword.
     fn get_a_keyword(input_reader: &mut InputReader<R>) -> Result<Token> {
-        let a = 
+        let a =
             input_reader.peek_until_discard_leading_spaces(InputReaderHelper::node_delimiter)?;
 
         if a.len() == 1 && a[0] == Some('a') {
-            // ok, don't forget to consume the 'a' character
-            let _ =  input_reader.get_next_char();
             return Ok(Token::KeywordA);
         } else {
             return Err(Error::new(
@@ -382,7 +380,10 @@ impl<R: Read> RdfLexer<R> for TurtleLexer<R> {
             Some('a') => {
                 // try parsing the 'a' keyword
                 match TurtleLexer::get_a_keyword(&mut self.input_reader) {
-                    Ok(token) => return Ok(token),
+                    Ok(token) => {
+                        TurtleLexer::consume_next_char(&mut self.input_reader);
+                        return Ok(token)
+                    },
                     _ => {} // continue, because it could still be a QName
                 }
             }


### PR DESCRIPTION
Hello, I'm not sure you're still working on this and accepting PRs. I was looking at Solid and was trying the code samples at https://solid.inrupt.com/docs/manipulating-ld-with-rdflib but decided to do it in Rust and use your library instead... But I ran into an issue parsing the turtle provided, so here's a fix, and an extra method to build URI nodes from slices and a fragment. This is very crude but I noted you wanted to move to use a proper URL type (maybe from servo/rust-url?) anyway.
I'm not sure if I'm going to have much time, but I find Solid interesting and maybe Rust implementations would be helpful. Do you still plan to expand on your library? Off the top of my head, I could see how we could turn Graph into a Trait and provide a DB backed implementation to get a full RDF store, be able to retrieve stuff from the web (Fetcher class in rdflib), etc. There's also a lot of code to parse Turtle for example you must have had great fun writing, would it be interesting to look at Rust parser combinators to do that? Or do you want to keep dependencies small?
Thanks!