### PR TITLE
If a literal is an integer, then we can write nicer turtle

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,6 +5,7 @@ use std::slice::Iter;
 use crate::triple::*;
 use crate::uri::Uri;
 use crate::Result;
+use crate::specs::xml_specs::XmlDataTypes;
 
 /// Representation of an RDF graph.
 #[derive(Debug)]
@@ -181,6 +182,14 @@ impl Graph {
         Node::LiteralNode {
             literal,
             data_type: None,
+            language: None,
+        }
+    }
+
+    pub fn create_integer_node(&self, literal: i32) -> Node {
+        Node::LiteralNode {
+            literal: literal.to_string(),
+            data_type: Some(XmlDataTypes::Integer.to_uri()),
             language: None,
         }
     }

--- a/src/writer/formatter/turtle_formatter.rs
+++ b/src/writer/formatter/turtle_formatter.rs
@@ -46,23 +46,27 @@ impl<'a> RdfFormatter for TurtleFormatter<'a> {
         let mut output_string = "".to_string();
 
         if TurtleSpecs::is_boolean_literal(literal) && *language == None && *data_type == None {
-            // some number or boolean
+            // some boolean
+            output_string.push_str(literal);
+        } else if TurtleSpecs::is_integer_literal(literal) && *language == None {
+            // some number
             output_string.push_str(literal);
         } else {
             output_string.push_str("\"");
             output_string.push_str(format!("{}", literal.escape_debug()).as_ref());
             output_string.push_str("\"");
+            if let Some(ref lang) = *language {
+                output_string.push_str("@");
+                output_string.push_str(lang);
+            }
+    
+            if let Some(ref dt) = *data_type {
+                output_string.push_str("^^");
+                output_string.push_str(&self.format_uri(dt));
+            }
         }
 
-        if let Some(ref lang) = *language {
-            output_string.push_str("@");
-            output_string.push_str(lang);
-        }
-
-        if let Some(ref dt) = *data_type {
-            output_string.push_str("^^");
-            output_string.push_str(&self.format_uri(dt));
-        }
+        
 
         output_string
     }

--- a/src/writer/turtle_writer.rs
+++ b/src/writer/turtle_writer.rs
@@ -336,4 +336,26 @@ _:auto2 <http://example.org/show/localName> _:auto1 ,
             Err(_) => assert!(false),
         }
     }
+
+    #[test]
+    fn test_turtle_writer_integer_literal() {
+        let mut graph = Graph::new(None);
+
+        graph.add_namespace(&Namespace::new(
+            "example".to_string(),
+            Uri::new("http://example.org/".to_string()),
+        ));
+        
+        let result = "@prefix example: <http://example.org/> .\n _:auto0 example.localName 1".to_string();
+        let subject1 = graph.create_blank_node();
+        let predicate1 = graph.create_uri_node(&Uri::new("http://example.org/show/localName".to_string()));
+        let object1 = graph.create_integer_node(1);
+        graph.add_triple(&Triple::new(&subject1, &predicate1, &object1));
+        
+        let writer = TurtleWriter::new(graph.namespaces());
+        match writer.write_to_string(&graph) {
+            Ok(str) => assert_eq!(result, str),
+            Err(_) => assert!(false),
+        }
+    }
 }


### PR DESCRIPTION
This is my first rust code ;) but I hope it is useful. Basically we can avoid writing xsd:integer when printing literal integers.